### PR TITLE
Fix automated update workflow

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -5,23 +5,23 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Set up git config
-        run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+      - uses: actions/checkout@v6
       - name: Run update script
         run: bash scripts/auto_update.sh
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
-          branch: auto/update-${{ github.run_id }}
+          branch: auto/update
+          delete-branch: true
           title: "Automated update"
           body: "Automated content update."
           commit-message: "Automated update"
+          add-paths: updates/update_log.md

--- a/scripts/auto_update.sh
+++ b/scripts/auto_update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 latest_commit=$(git log -1 --pretty=format:%H)
 latest_msg=$(git log -1 --pretty=format:%s)
@@ -8,8 +8,3 @@ mkdir -p updates
 log_file="updates/update_log.md"
 
 echo "- $(date -u +"%Y-%m-%d %H:%M:%S") UTC - last commit $latest_commit: $latest_msg" >> "$log_file"
-
-git add "$log_file"
-
-git commit -m "Automated update" && git push || echo "No changes to commit"
-


### PR DESCRIPTION
### Motivation
- The scheduled automated update workflow was failing to create update branches and pull requests due to missing workflow permissions and out-of-date action versions.
- The update script performed its own `git` commit/push which conflicted with the `create-pull-request` action semantics and caused unreliable behavior.

### Description
- Added explicit workflow `permissions` with `contents: write` and `pull-requests: write` so `GITHUB_TOKEN` can create branches and PRs.
- Upgraded actions to current majors: `actions/checkout@v6` and `peter-evans/create-pull-request@v8` and configured `create-pull-request` with `branch: auto/update`, `delete-branch: true`, and `add-paths: updates/update_log.md`.
- Simplified `scripts/auto_update.sh` to use `set -euo pipefail` and to only append to `updates/update_log.md`, removing the manual `git add/commit/push` from the script.

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto_update.yml')"` which succeeded.
- Performed a shell syntax check with `bash -n scripts/auto_update.sh` which succeeded.
- Executed `bash scripts/auto_update.sh` and observed `updates/update_log.md` being updated, which succeeded.
- Ran `git diff --check` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221e5d443c832fad178ed67291a233)