### PR TITLE
Add Limitless Drive preservation prototype and content-addressed indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
 # Quantum Chemistry
 
-This repository tracks the evolution of a self-building Quantum Chemistry textbook.
-Automated updates occur every 15 minutes via GitHub Actions.
+This repository tracks the evolution of a self-building Quantum Chemistry
+textbook and adjacent experiments in durable, agent-coordinated knowledge
+preservation. Automated updates occur every 15 minutes via GitHub Actions.
+
+## Limitless Drive prototype
+
+The repository now includes a local-first preservation prototype for a
+content-addressed virtual drive that can later be published through IPFS/IPNS.
+It is not a production storage network by itself; it provides the manifesting
+foundation needed to identify unique files and exported emails, detect duplicate
+payloads, and retain every discovered source location before pinning or mounting.
+
+Key pieces:
+
+- `docs/limitless-drive.md` describes the IPFS/IPNS, GitOS, A2A, security, and
+  deletion-safety blueprint.
+- `src/limitless_drive/indexer.py` builds a CIDv1-style multibase manifest for
+  regular files and `.mbox` email archives.
+- `tests/test_indexer.py` covers deterministic IDs, deduplication, mailbox
+  indexing, and CLI manifest output.
+
+Run the prototype against one or more directories or files:
+
+```bash
+python -m limitless_drive.indexer ~/Pictures ~/Documents mail-export.mbox \
+  --output limitless-manifest.json
+```

--- a/docs/limitless-drive.md
+++ b/docs/limitless-drive.md
@@ -1,0 +1,76 @@
+# Limitless Drive Blueprint
+
+Limitless Drive is a local-first preservation layer for personal files and email
+that can be published through IPFS and resolved through IPNS. It is designed as a
+virtual disk drive that mounts on phones, laptops, desktops, and home servers
+while keeping the canonical state in a GitOS-style append-only history.
+
+## Goals
+
+- Preserve family artifacts, memories, files, and email without accidental loss.
+- Address every unique object by content using CIDv1-compatible multibase names.
+- Deduplicate identical payloads while retaining every original location and
+  contextual label.
+- Treat deletion as a reversible intent, not destruction, until retention policy,
+  quorum, and human review checks pass.
+- Use agent-to-agent (A2A) coordination so devices, backup nodes, scanners, and
+  recovery agents can negotiate sync without a single privileged automaton.
+
+## Architecture
+
+1. **Local capture agents** watch selected folders, removable drives, camera
+   imports, and exported mailboxes. They only append observations to manifests.
+2. **Content-addressed object store** chunks and pins payloads in IPFS. The
+   included `limitless-index` prototype emits CIDv1-style base32 multibase IDs
+   for whole-file and whole-email payloads before publication.
+3. **GitOS ledger** commits manifests, policy files, revocation events, and IPNS
+   pointer updates. Each commit is a signed checkpoint that devices can audit.
+4. **IPNS namespace** publishes the current root manifest and latest safe mount
+   view. Old roots remain reachable from the GitOS ledger and local pins.
+5. **Virtual drive mount** exposes files through a FUSE/WebDAV/mobile-provider
+   adapter. The mounted view is reconstructed from manifests, not from mutable
+   path names alone.
+6. **Email account vault** imports mbox/Maildir/IMAP exports as immutable
+   `message/rfc822` artifacts, preserving message IDs, subjects, dates, and
+   mailbox provenance as metadata.
+
+## Security model
+
+- **Quantum-resistant envelope option:** encrypt data keys to post-quantum KEM
+  recipients, while retaining conventional authenticated encryption for payloads.
+- **Device keys:** every device has its own signing key and revocation record.
+- **Movement-based identification:** local unlock policy can combine device-held
+  keys with consented motion biometrics, such as gait or familiar gesture
+  classifiers, but motion signals must never be the sole recovery factor.
+- **A2A least privilege:** scanner, dedupe, pinning, mount, and recovery agents
+  exchange signed tasks with bounded capabilities.
+- **Tamper evidence:** manifests store hashes, CIDs, sizes, timestamps, and
+  source locations so unexpected mutation is detectable.
+
+## Loss-prevention policy
+
+Deletion requests create tombstone proposals. A proposal is eligible for garbage
+collection only after all of these checks pass:
+
+1. the content exists in at least the configured number of independent pins;
+2. a newer manifest confirms no protected album, mailbox, or artifact collection
+   references the content;
+3. the retention window has expired;
+4. a human recovery contact or owner quorum signs the removal;
+5. the GitOS ledger contains the tombstone, approvals, and final collection
+   receipt.
+
+Until then, the virtual drive hides the item only in the requested view while the
+underlying object remains pinned and recoverable.
+
+## Prototype usage
+
+Create a local manifest without changing source data:
+
+```bash
+python -m limitless_drive.indexer ~/Pictures ~/Documents mail-export.mbox \
+  --output limitless-manifest.json
+```
+
+The manifest reports unique artifacts and duplicate content groups. Duplicate
+entries are grouped by CID while retaining every discovered source location.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "limitless-drive"
+version = "0.1.0"
+description = "Content-addressed preservation index prototype for IPFS/IPNS-backed personal archives."
+requires-python = ">=3.10"
+readme = "README.md"
+
+[project.scripts]
+limitless-index = "limitless_drive.indexer:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/limitless_drive/__init__.py
+++ b/src/limitless_drive/__init__.py
@@ -1,0 +1,4 @@
+"""Limitless Drive preservation tooling."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/limitless_drive/indexer.py
+++ b/src/limitless_drive/indexer.py
@@ -1,0 +1,164 @@
+"""Build a content-addressed manifest for files and exported email archives.
+
+The manifest is intentionally local-first: it never deletes source data and it
+can be generated before IPFS/IPNS publication.  Each payload receives a CID-like
+multibase identifier derived from a SHA-256 multihash so duplicate bytes can be
+recognized across drives, folders, email exports, and historical archives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import mailbox
+import mimetypes
+import os
+import stat
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from email.message import Message
+from pathlib import Path
+from typing import Iterable, Iterator
+
+CIDV1_RAW_SHA256_PREFIX = bytes([0x01, 0x55, 0x12, 0x20])
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """A single preserved object in a local archive."""
+
+    cid: str
+    kind: str
+    size: int
+    sha256: str
+    locations: list[str]
+    mime_type: str | None = None
+    subject: str | None = None
+    message_id: str | None = None
+    modified_utc: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+def cidv1_raw_sha256(payload: bytes) -> str:
+    """Return a CIDv1-style base32 multibase string for raw SHA-256 content."""
+
+    digest = hashlib.sha256(payload).digest()
+    cid_bytes = CIDV1_RAW_SHA256_PREFIX + digest
+    return "b" + base64.b32encode(cid_bytes).decode("ascii").lower().rstrip("=")
+
+
+def _utc_timestamp(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _safe_location(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def iter_files(roots: Iterable[Path]) -> Iterator[Path]:
+    """Yield regular files under roots without following symlinked files."""
+
+    for root in roots:
+        if root.is_file() and not root.is_symlink():
+            yield root
+            continue
+        for directory, dirnames, filenames in os.walk(root, followlinks=False):
+            dirnames[:] = [name for name in dirnames if not (Path(directory) / name).is_symlink()]
+            for filename in filenames:
+                path = Path(directory) / filename
+                try:
+                    mode = path.lstat().st_mode
+                except OSError:
+                    continue
+                if stat.S_ISREG(mode):
+                    yield path
+
+
+def artifact_from_file(path: Path, root: Path) -> Artifact:
+    payload = path.read_bytes()
+    guessed_mime, _ = mimetypes.guess_type(path.name)
+    digest = hashlib.sha256(payload).hexdigest()
+    return Artifact(
+        cid=cidv1_raw_sha256(payload),
+        kind="file",
+        size=len(payload),
+        sha256=digest,
+        locations=[_safe_location(path, root)],
+        mime_type=guessed_mime,
+        modified_utc=_utc_timestamp(path.stat().st_mtime),
+    )
+
+
+def _message_payload(message: Message) -> bytes:
+    return message.as_bytes(unixfrom=False)
+
+
+def artifacts_from_mbox(path: Path, root: Path) -> Iterator[Artifact]:
+    archive = mailbox.mbox(path)
+    for index, message in enumerate(archive):
+        payload = _message_payload(message)
+        location = f"{_safe_location(path, root)}#message-{index}"
+        yield Artifact(
+            cid=cidv1_raw_sha256(payload),
+            kind="email",
+            size=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+            locations=[location],
+            mime_type="message/rfc822",
+            subject=message.get("subject"),
+            message_id=message.get("message-id"),
+            metadata={"from": message.get("from", ""), "date": message.get("date", "")},
+        )
+
+
+def build_manifest(paths: Iterable[Path]) -> dict[str, object]:
+    roots = [path.resolve() for path in paths]
+    by_cid: dict[str, Artifact] = {}
+    for file_path in iter_files(roots):
+        root = next((candidate for candidate in roots if candidate == file_path.resolve() or candidate in file_path.resolve().parents), file_path.parent.resolve())
+        artifacts: Iterable[Artifact]
+        if file_path.suffix.lower() == ".mbox":
+            artifacts = artifacts_from_mbox(file_path, root)
+        else:
+            artifacts = [artifact_from_file(file_path, root)]
+        for artifact in artifacts:
+            existing = by_cid.get(artifact.cid)
+            if existing is None:
+                by_cid[artifact.cid] = artifact
+            else:
+                locations = sorted({*existing.locations, *artifact.locations})
+                by_cid[artifact.cid] = Artifact(**{**asdict(existing), "locations": locations})
+
+    artifacts_list = sorted((asdict(item) for item in by_cid.values()), key=lambda item: item["cid"])
+    duplicates = [item for item in artifacts_list if len(item["locations"]) > 1]
+    return {
+        "schema": "limitless-drive.manifest.v1",
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "artifact_count": len(artifacts_list),
+        "duplicate_content_groups": len(duplicates),
+        "artifacts": artifacts_list,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a content-addressed preservation manifest.")
+    parser.add_argument("paths", nargs="+", type=Path, help="Files or directories to index")
+    parser.add_argument("--output", "-o", type=Path, default=Path("limitless-manifest.json"), help="Manifest path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = build_manifest(args.paths)
+    args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"indexed {manifest['artifact_count']} unique artifacts; duplicate groups: {manifest['duplicate_content_groups']}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,56 @@
+import json
+from email.message import EmailMessage
+
+from limitless_drive.indexer import build_manifest, cidv1_raw_sha256, main
+
+
+def test_cid_is_stable_multibase_base32():
+    cid = cidv1_raw_sha256(b"family photo bytes")
+
+    assert cid.startswith("b")
+    assert cid == cidv1_raw_sha256(b"family photo bytes")
+    assert cid != cidv1_raw_sha256(b"different bytes")
+
+
+def test_manifest_deduplicates_files_and_keeps_locations(tmp_path):
+    (tmp_path / "a.txt").write_text("same memory", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "copy.txt").write_text("same memory", encoding="utf-8")
+
+    manifest = build_manifest([tmp_path])
+
+    assert manifest["artifact_count"] == 1
+    assert manifest["duplicate_content_groups"] == 1
+    assert sorted(manifest["artifacts"][0]["locations"]) == ["a.txt", "nested/copy.txt"]
+
+
+def test_mbox_messages_are_indexed(tmp_path):
+    message = EmailMessage()
+    message["From"] = "alice@example.test"
+    message["To"] = "family@example.test"
+    message["Subject"] = "Picnic"
+    message["Message-ID"] = "<picnic@example.test>"
+    message.set_content("remember this day")
+    mbox = tmp_path / "mail.mbox"
+    mbox.write_text("From alice Sat Jan 01 00:00:00 2022\n" + message.as_string() + "\n", encoding="utf-8")
+
+    manifest = build_manifest([tmp_path])
+
+    assert manifest["artifact_count"] == 1
+    artifact = manifest["artifacts"][0]
+    assert artifact["kind"] == "email"
+    assert artifact["subject"] == "Picnic"
+    assert artifact["message_id"] == "<picnic@example.test>"
+
+
+def test_cli_writes_manifest(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "note.txt").write_text("do not lose", encoding="utf-8")
+    output = tmp_path / "manifest.json"
+
+    assert main([str(source), "--output", str(output)]) == 0
+    manifest = json.loads(output.read_text(encoding="utf-8"))
+    assert manifest["schema"] == "limitless-drive.manifest.v1"
+    assert manifest["artifact_count"] == 1


### PR DESCRIPTION
### Motivation
- Provide a local-first preservation manifest generator that can form the basis for IPFS/IPNS-backed virtual drives and GitOS-style append-only histories.
- Ensure every unique file or exported email is addressed by a stable content identifier so duplicate payloads are detected and original source locations are preserved.
- Deliver a prototype foundation for dedupe, pinning, A2A coordination, quantum-resistant key envelopes, and movement-based identification without destructive local deletes.

### Description
- Add `src/limitless_drive/indexer.py` which implements file discovery (without following symlinked files), `.mbox` email extraction, the `cidv1_raw_sha256` multibase ID, an `Artifact` dataclass, deduplication by CID, and JSON manifest output.
- Add documentation `docs/limitless-drive.md` and update `README.md` describing architecture, security model, loss-prevention policy, and usage (example: `python -m limitless_drive.indexer ...`).
- Add packaging metadata `pyproject.toml`, package init `src/limitless_drive/__init__.py`, a CLI entry `limitless-index = "limitless_drive.indexer:main"`, and tests `tests/test_indexer.py` that exercise deterministic IDs, dedupe/location retention, mbox indexing, and CLI manifest output.

### Testing
- Ran the automated test suite with `python -m pytest -q`.
- The test run succeeded: `4 passed in 0.13s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a973a2da0832f85cfda91fb975f78)