### PR TITLE
Add local voice interface scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,78 @@
-# Quantum Chemistry
+# Voice Interface
 
-This repository tracks the evolution of a self-building Quantum Chemistry
-textbook and adjacent experiments in durable, agent-coordinated knowledge
-preservation. Automated updates occur every 15 minutes via GitHub Actions.
+A lightweight, local-first Python library and CLI foundation for room-scale
+human-computer voice interaction. The project is designed around streaming STT,
+streaming TTS, VAD-driven turn taking, interruption handling, and a plugin layer
+for voice-triggered tools while keeping cloud calls opt-in only.
 
-## Limitless Drive prototype
+## Goals
 
-The repository now includes a local-first preservation prototype for a
-content-addressed virtual drive that can later be published through IPFS/IPNS.
-It is not a production storage network by itself; it provides the manifesting
-foundation needed to identify unique files and exported emails, detect duplicate
-payloads, and retain every discovered source location before pinning or mounting.
+- **Offline by default:** no network calls during import or normal operation.
+- **Low latency:** chunk-oriented ASR/TTS boundaries suitable for 80-300 ms loops.
+- **Full duplex:** pause/stop speech output when new human speech arrives.
+- **Extensible:** swap ASR, VAD, TTS, LLM, diarization, and GUI frontends.
+- **Room-ready:** provide primitives for multi-mic and multi-speaker evolution.
 
-Key pieces:
-
-- `docs/limitless-drive.md` describes the IPFS/IPNS, GitOS, A2A, security, and
-  deletion-safety blueprint.
-- `src/limitless_drive/indexer.py` builds a CIDv1-style multibase manifest for
-  regular files and `.mbox` email archives.
-- `tests/test_indexer.py` covers deterministic IDs, deduplication, mailbox
-  indexing, and CLI manifest output.
-
-Run the prototype against one or more directories or files:
+## Install
 
 ```bash
-python -m limitless_drive.indexer ~/Pictures ~/Documents mail-export.mbox \
-  --output limitless-manifest.json
+python -m pip install -e .
 ```
+
+Optional local backends can be installed as needed:
+
+```bash
+python -m pip install -e '.[audio,piper,nemotron,diarization,llm]'
+```
+
+Model downloads are intentionally explicit so deployments can prepare an offline
+model cache. The default ASR target is `nvidia/nemotron-3.5-asr-streaming-0.6b`;
+the default TTS target is Piper.
+
+## CLI
+
+Run an offline deterministic smoke demo without model downloads:
+
+```bash
+voice-interface demo --say "Hey computer, summarize the room notes."
+```
+
+Check optional backend guidance:
+
+```bash
+voice-interface doctor
+```
+
+## Python API
+
+```python
+from voice_interface.asr.nemotron import ScriptedASR
+from voice_interface.conversation.loop import ConversationLoop
+from voice_interface.tts.piper import PiperTTS
+
+loop = ConversationLoop(ScriptedASR(["Hello computer."]), PiperTTS())
+turns = loop.handle_audio([b"\1\0" * 800])
+print(turns[0].assistant_text)
+```
+
+## Architecture
+
+- `voice_interface.asr` contains the optional Nemotron adapter plus test/demo ASR.
+- `voice_interface.audio` contains local VAD primitives.
+- `voice_interface.tts` contains a Piper adapter with an offline fallback tone.
+- `voice_interface.conversation` coordinates STT → responder/LLM → TTS.
+- `voice_interface.plugins` registers local voice commands/actions.
+- `voice_interface.gui` is reserved for lightweight Streamlit/Tauri frontends.
+
+## Roadmap
+
+1. Core Nemotron cache-aware streaming adapter and real microphone input.
+2. Streaming Piper/StyleTTS output with robust barge-in playback controls.
+3. Local diarization and speaker clustering for multi-human rooms.
+4. Ollama/llama.cpp integration, persistent memory, GUI status display, and docs.
+
+## Legacy prototype
+
+The existing `limitless_drive` preservation index remains available through the
+`limitless-index` console script while this repository evolves toward the local
+voice-interface library.

--- a/docs/voice-interface.md
+++ b/docs/voice-interface.md
@@ -1,0 +1,20 @@
+# Voice Interface Design Notes
+
+The core package is intentionally dependency-light. Heavy engines such as NeMo,
+Piper, pyannote, sounddevice, or local LLM clients are isolated behind optional
+extras so the CLI, tests, and plugin development work offline on any platform.
+
+## Runtime pipeline
+
+1. Audio frontend captures PCM chunks from one or more microphones.
+2. VAD marks speech and silence boundaries for natural turn-taking.
+3. Streaming ASR produces partial and final `TranscriptEvent` objects.
+4. Conversation orchestration forwards final text to a local responder or LLM.
+5. Streaming TTS emits `AudioChunk` objects and can be stopped for barge-in.
+6. Plugins can intercept recognized commands before or after LLM handling.
+
+## Privacy posture
+
+Imports and deterministic demos do not perform network calls. Model downloads,
+cloud fallbacks, and remote LLM endpoints must be explicitly configured by the
+operator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,22 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "limitless-drive"
+name = "voice-interface"
 version = "0.1.0"
-description = "Content-addressed preservation index prototype for IPFS/IPNS-backed personal archives."
-requires-python = ">=3.10"
+description = "Local-first streaming STT/TTS room voice interface for offline human-computer interaction."
+requires-python = ">=3.11"
 readme = "README.md"
 
+[project.optional-dependencies]
+audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
+nemotron = ["nemo-toolkit[asr]>=2.0"]
+piper = ["piper-tts>=1.2"]
+diarization = ["pyannote.audio>=3.1"]
+llm = ["httpx>=0.27"]
+all = ["sounddevice>=0.4.6", "numpy>=1.26", "piper-tts>=1.2", "pyannote.audio>=3.1", "httpx>=0.27"]
+
 [project.scripts]
+voice-interface = "voice_interface.cli:main"
 limitless-index = "limitless_drive.indexer:main"
 
 [tool.pytest.ini_options]

--- a/src/voice_interface/__init__.py
+++ b/src/voice_interface/__init__.py
@@ -1,0 +1,6 @@
+"""Local, privacy-first voice interface toolkit."""
+
+from voice_interface.config import VoiceInterfaceConfig
+from voice_interface.conversation.loop import ConversationLoop, ConversationTurn
+
+__all__ = ["ConversationLoop", "ConversationTurn", "VoiceInterfaceConfig"]

--- a/src/voice_interface/asr/__init__.py
+++ b/src/voice_interface/asr/__init__.py
@@ -1,0 +1,4 @@
+from voice_interface.asr.base import StreamingASR, TranscriptEvent
+from voice_interface.asr.nemotron import NemotronStreamingASR, ScriptedASR
+
+__all__ = ["NemotronStreamingASR", "ScriptedASR", "StreamingASR", "TranscriptEvent"]

--- a/src/voice_interface/asr/base.py
+++ b/src/voice_interface/asr/base.py
@@ -1,0 +1,24 @@
+"""ASR interfaces and lightweight transcript types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptEvent:
+    text: str
+    is_final: bool
+    speaker: str | None = None
+    language: str | None = None
+    start_ms: int | None = None
+    end_ms: int | None = None
+
+
+class StreamingASR(Protocol):
+    def start(self) -> None: ...
+
+    def transcribe_chunk(self, pcm16: bytes) -> TranscriptEvent | None: ...
+
+    def finish(self) -> TranscriptEvent | None: ...

--- a/src/voice_interface/asr/nemotron.py
+++ b/src/voice_interface/asr/nemotron.py
@@ -1,0 +1,76 @@
+"""Adapter for NVIDIA Nemotron streaming ASR.
+
+The module keeps heavyweight NeMo dependencies optional. In production, install
+`voice-interface[nemotron]` and use :class:`NemotronStreamingASR`; tests can use
+:class:`ScriptedASR` from this module without model files or network access.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+
+from voice_interface.asr.base import TranscriptEvent
+from voice_interface.config import ASRConfig
+
+
+class NemotronStreamingASR:
+    """Lazy wrapper around a cache-aware Nemotron streaming recognizer."""
+
+    def __init__(self, config: ASRConfig | None = None) -> None:
+        self.config = config or ASRConfig()
+        self._engine = None
+        self._started = False
+
+    def start(self) -> None:
+        """Initialize optional NeMo components only when the stream starts."""
+
+        if self._started:
+            return
+        try:
+            import nemo.collections.asr as nemo_asr  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "Nemotron ASR requires optional NVIDIA NeMo dependencies. "
+                "Install with `pip install voice-interface[nemotron]` and "
+                "download the model explicitly for offline use."
+            ) from exc
+        self._engine = nemo_asr.models.ASRModel.from_pretrained(self.config.model)
+        self._started = True
+
+    def transcribe_chunk(self, pcm16: bytes) -> TranscriptEvent | None:
+        if not pcm16:
+            return None
+        if self._engine is None:  # pragma: no cover - backend-specific
+            raise RuntimeError("ASR stream has not been started")
+        # NeMo streaming APIs vary by release; keep the boundary isolated here.
+        result = self._engine.transcribe([pcm16], batch_size=1)  # type: ignore[attr-defined]
+        text = result[0] if result else ""
+        return TranscriptEvent(text=text, is_final=False, language=self.config.language)
+
+    def finish(self) -> TranscriptEvent | None:
+        return None
+
+
+class ScriptedASR:
+    """Deterministic ASR for tests, demos, and plugin development."""
+
+    def __init__(self, events: Iterable[str | TranscriptEvent]) -> None:
+        self.events = deque(
+            event if isinstance(event, TranscriptEvent) else TranscriptEvent(text=event, is_final=True)
+            for event in events
+        )
+
+    def start(self) -> None:
+        return None
+
+    def transcribe_chunk(self, pcm16: bytes) -> TranscriptEvent | None:
+        if not pcm16 or not self.events:
+            return None
+        return self.events.popleft()
+
+    def finish(self) -> TranscriptEvent | None:
+        if self.events:
+            event = self.events.popleft()
+            return TranscriptEvent(text=event.text, is_final=True, speaker=event.speaker, language=event.language)
+        return None

--- a/src/voice_interface/audio/__init__.py
+++ b/src/voice_interface/audio/__init__.py
@@ -1,0 +1,3 @@
+from voice_interface.audio.vad import EnergyVAD, VADEvent
+
+__all__ = ["EnergyVAD", "VADEvent"]

--- a/src/voice_interface/audio/vad.py
+++ b/src/voice_interface/audio/vad.py
@@ -1,0 +1,30 @@
+"""Voice activity detection helpers."""
+
+from __future__ import annotations
+
+import math
+import struct
+from dataclasses import dataclass
+
+from voice_interface.config import VADConfig
+
+
+@dataclass(slots=True)
+class VADEvent:
+    is_speech: bool
+    rms: float
+
+
+class EnergyVAD:
+    """Dependency-free VAD suitable as a conservative default/fallback."""
+
+    def __init__(self, config: VADConfig | None = None) -> None:
+        self.config = config or VADConfig()
+
+    def analyze(self, pcm16: bytes) -> VADEvent:
+        if len(pcm16) < 2:
+            return VADEvent(is_speech=False, rms=0.0)
+        sample_count = len(pcm16) // 2
+        samples = struct.unpack("<" + "h" * sample_count, pcm16[: sample_count * 2])
+        rms = math.sqrt(sum(sample * sample for sample in samples) / sample_count) / 32768.0
+        return VADEvent(is_speech=rms >= self.config.speech_threshold, rms=rms)

--- a/src/voice_interface/cli.py
+++ b/src/voice_interface/cli.py
@@ -1,0 +1,35 @@
+"""Command-line entry points for local voice-interface demos."""
+
+from __future__ import annotations
+
+import argparse
+
+from voice_interface.asr.nemotron import ScriptedASR
+from voice_interface.conversation.loop import ConversationLoop
+from voice_interface.tts.piper import PiperTTS
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a local voice-interface demo or daemon.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    demo = sub.add_parser("demo", help="Run an offline scripted full-duplex smoke demo")
+    demo.add_argument("--say", default="Hello computer.", help="Scripted utterance to feed into the loop")
+    sub.add_parser("doctor", help="Print optional backend installation guidance")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "doctor":
+        print("Core package is installed. Optional extras: [nemotron], [piper], [audio], [diarization], [llm].")
+        return 0
+    loop = ConversationLoop(ScriptedASR([args.say]), PiperTTS())
+    turns = loop.handle_audio([b"\1\0" * 800])
+    for turn in turns:
+        print(f"user: {turn.user_text}")
+        print(f"assistant: {turn.assistant_text}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/voice_interface/config.py
+++ b/src/voice_interface/config.py
@@ -1,0 +1,67 @@
+"""Configuration models for the local voice interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class ASRConfig:
+    """Streaming ASR configuration.
+
+    The defaults match a low-latency local setup. Model downloads are explicit
+    and handled by optional backend packages, never by importing this library.
+    """
+
+    backend: str = "nemotron"
+    model: str = "nvidia/nemotron-3.5-asr-streaming-0.6b"
+    chunk_ms: int = 160
+    language: str = "auto"
+    device: str = "auto"
+    cache_aware: bool = True
+
+
+@dataclass(slots=True)
+class VADConfig:
+    backend: str = "energy"
+    sample_rate: int = 16_000
+    frame_ms: int = 30
+    speech_threshold: float = 0.015
+    silence_ms: int = 450
+
+
+@dataclass(slots=True)
+class TTSConfig:
+    backend: str = "piper"
+    voice: str = "en_US-lessac-medium"
+    speaker: str | None = None
+    sample_rate: int = 22_050
+    stream_chunk_ms: int = 80
+
+
+@dataclass(slots=True)
+class LLMConfig:
+    backend: str = "echo"
+    model: str | None = None
+    endpoint: str = "http://localhost:11434/api/generate"
+    system_prompt: str = "You are a concise, helpful local room assistant."
+
+
+@dataclass(slots=True)
+class RoomConfig:
+    input_device: str | int | None = None
+    output_device: str | int | None = None
+    microphone_channels: int = 1
+    wake_word: str | None = None
+    allow_network: bool = False
+
+
+@dataclass(slots=True)
+class VoiceInterfaceConfig:
+    asr: ASRConfig = field(default_factory=ASRConfig)
+    vad: VADConfig = field(default_factory=VADConfig)
+    tts: TTSConfig = field(default_factory=TTSConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+    room: RoomConfig = field(default_factory=RoomConfig)
+    session_path: Path = Path(".voice-interface/session.jsonl")

--- a/src/voice_interface/conversation/__init__.py
+++ b/src/voice_interface/conversation/__init__.py
@@ -1,0 +1,3 @@
+from voice_interface.conversation.loop import ConversationLoop, ConversationTurn
+
+__all__ = ["ConversationLoop", "ConversationTurn"]

--- a/src/voice_interface/conversation/loop.py
+++ b/src/voice_interface/conversation/loop.py
@@ -1,0 +1,66 @@
+"""Full-duplex conversation orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from voice_interface.asr.base import StreamingASR, TranscriptEvent
+from voice_interface.tts.base import AudioChunk, StreamingTTS
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationTurn:
+    user_text: str
+    assistant_text: str
+    speaker: str | None = None
+
+
+class ConversationLoop:
+    """Coordinates STT → responder/LLM → TTS with barge-in support."""
+
+    def __init__(
+        self,
+        asr: StreamingASR,
+        tts: StreamingTTS,
+        responder: Callable[[str], str] | None = None,
+    ) -> None:
+        self.asr = asr
+        self.tts = tts
+        self.responder = responder or (lambda text: f"I heard: {text}")
+        self.turns: list[ConversationTurn] = []
+        self._speaking = False
+
+    def handle_audio(self, pcm_chunks: Iterable[bytes]) -> list[ConversationTurn]:
+        self.asr.start()
+        completed: list[ConversationTurn] = []
+        for chunk in pcm_chunks:
+            event = self.asr.transcribe_chunk(chunk)
+            if event is None:
+                continue
+            if self._speaking and event.text.strip():
+                self.tts.stop()
+                self._speaking = False
+            if event.is_final and event.text.strip():
+                completed.append(self._answer(event))
+        final = self.asr.finish()
+        if final and final.text.strip():
+            completed.append(self._answer(final))
+        return completed
+
+    def _answer(self, event: TranscriptEvent) -> ConversationTurn:
+        assistant_text = self.responder(event.text)
+        self._speaking = True
+        for audio in self.tts.synthesize_stream(assistant_text):
+            self._consume_audio(audio)
+            if audio.is_final:
+                break
+        self._speaking = False
+        turn = ConversationTurn(user_text=event.text, assistant_text=assistant_text, speaker=event.speaker)
+        self.turns.append(turn)
+        return turn
+
+    def _consume_audio(self, audio: AudioChunk) -> None:
+        # Real audio playback is implemented by CLI/daemon frontends so this
+        # core loop remains easy to test and embed.
+        return None

--- a/src/voice_interface/gui/__init__.py
+++ b/src/voice_interface/gui/__init__.py
@@ -1,0 +1,1 @@
+"""Placeholder package for optional lightweight GUI frontends."""

--- a/src/voice_interface/plugins/__init__.py
+++ b/src/voice_interface/plugins/__init__.py
@@ -1,0 +1,3 @@
+from voice_interface.plugins.registry import PluginRegistry, VoiceCommand
+
+__all__ = ["PluginRegistry", "VoiceCommand"]

--- a/src/voice_interface/plugins/registry.py
+++ b/src/voice_interface/plugins/registry.py
@@ -1,0 +1,28 @@
+"""Simple local voice action plugin registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceCommand:
+    name: str
+    phrase: str
+    handler: Callable[[str], str]
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._commands: list[VoiceCommand] = []
+
+    def register(self, command: VoiceCommand) -> None:
+        self._commands.append(command)
+
+    def dispatch(self, text: str) -> str | None:
+        normalized = text.casefold()
+        for command in self._commands:
+            if command.phrase.casefold() in normalized:
+                return command.handler(text)
+        return None

--- a/src/voice_interface/tts/__init__.py
+++ b/src/voice_interface/tts/__init__.py
@@ -1,0 +1,4 @@
+from voice_interface.tts.base import AudioChunk, StreamingTTS
+from voice_interface.tts.piper import PiperTTS
+
+__all__ = ["AudioChunk", "PiperTTS", "StreamingTTS"]

--- a/src/voice_interface/tts/base.py
+++ b/src/voice_interface/tts/base.py
@@ -1,0 +1,19 @@
+"""TTS interfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class AudioChunk:
+    pcm16: bytes
+    sample_rate: int
+    is_final: bool = False
+
+
+class StreamingTTS(Protocol):
+    def synthesize_stream(self, text: str): ...
+
+    def stop(self) -> None: ...

--- a/src/voice_interface/tts/piper.py
+++ b/src/voice_interface/tts/piper.py
@@ -1,0 +1,52 @@
+"""Local Piper TTS integration with a deterministic fallback."""
+
+from __future__ import annotations
+
+import math
+import struct
+from collections.abc import Iterator
+
+from voice_interface.config import TTSConfig
+from voice_interface.tts.base import AudioChunk
+
+
+class PiperTTS:
+    def __init__(self, config: TTSConfig | None = None) -> None:
+        self.config = config or TTSConfig()
+        self._stopped = False
+
+    def synthesize_stream(self, text: str) -> Iterator[AudioChunk]:
+        """Yield local audio chunks.
+
+        If Piper bindings are unavailable, emit a short quiet tone so the rest
+        of the full-duplex pipeline remains testable offline.
+        """
+
+        self._stopped = False
+        try:
+            from piper.voice import PiperVoice  # type: ignore[import-not-found]
+        except ImportError:
+            yield from self._fallback_tone(text)
+            return
+        voice = PiperVoice.load(self.config.voice)  # pragma: no cover - optional
+        for chunk in voice.synthesize_stream_raw(text):  # pragma: no cover
+            if self._stopped:
+                break
+            yield AudioChunk(pcm16=chunk, sample_rate=self.config.sample_rate)
+        yield AudioChunk(pcm16=b"", sample_rate=self.config.sample_rate, is_final=True)
+
+    def _fallback_tone(self, text: str) -> Iterator[AudioChunk]:
+        duration = min(0.8, max(0.08, len(text) / 120.0))
+        total = int(self.config.sample_rate * duration)
+        frame_count = max(1, int(self.config.sample_rate * self.config.stream_chunk_ms / 1000))
+        for offset in range(0, total, frame_count):
+            if self._stopped:
+                break
+            samples = []
+            for index in range(offset, min(offset + frame_count, total)):
+                samples.append(int(1200 * math.sin(2 * math.pi * 220 * index / self.config.sample_rate)))
+            yield AudioChunk(pcm16=struct.pack("<" + "h" * len(samples), *samples), sample_rate=self.config.sample_rate)
+        yield AudioChunk(pcm16=b"", sample_rate=self.config.sample_rate, is_final=True)
+
+    def stop(self) -> None:
+        self._stopped = True

--- a/tests/test_voice_interface.py
+++ b/tests/test_voice_interface.py
@@ -1,0 +1,39 @@
+from voice_interface.audio.vad import EnergyVAD
+from voice_interface.asr.nemotron import ScriptedASR
+from voice_interface.cli import main
+from voice_interface.conversation.loop import ConversationLoop
+from voice_interface.plugins.registry import PluginRegistry, VoiceCommand
+from voice_interface.tts.piper import PiperTTS
+
+
+def test_scripted_conversation_loop_returns_spoken_turn():
+    loop = ConversationLoop(ScriptedASR(["Open the lab notes."]), PiperTTS(), responder=lambda text: f"Action: {text}")
+
+    turns = loop.handle_audio([b"\1\0" * 400])
+
+    assert len(turns) == 1
+    assert turns[0].user_text == "Open the lab notes."
+    assert turns[0].assistant_text == "Action: Open the lab notes."
+
+
+def test_energy_vad_detects_silence_and_speech():
+    vad = EnergyVAD()
+
+    assert not vad.analyze(b"\0\0" * 160).is_speech
+    assert vad.analyze((10000).to_bytes(2, "little", signed=True) * 160).is_speech
+
+
+def test_plugin_registry_dispatches_matching_voice_command():
+    registry = PluginRegistry()
+    registry.register(VoiceCommand("lights", "turn on lights", lambda text: f"matched {text}"))
+
+    assert registry.dispatch("Please turn on lights in the room") == "matched Please turn on lights in the room"
+    assert registry.dispatch("what time is it") is None
+
+
+def test_cli_demo_outputs_transcript(capsys):
+    assert main(["demo", "--say", "Testing local voice."]) == 0
+
+    output = capsys.readouterr().out
+    assert "user: Testing local voice." in output
+    assert "assistant: I heard: Testing local voice." in output


### PR DESCRIPTION
### Motivation
- Provide a lightweight, local-first scaffold for room-scale streaming STT/TTS and full-duplex voice interaction with privacy-by-default and optional heavyweight backends.
- Isolate heavy engines behind optional extras and include deterministic/demo implementations so core development and tests work offline.

### Description
- Add a new `voice_interface` package with configuration models in `src/voice_interface/config.py` and a top-level package `src/voice_interface/__init__.py`.
- Implement ASR primitives and adapters in `src/voice_interface/asr/` including `base.py`, an optional `NemotronStreamingASR` adapter, and a `ScriptedASR` for deterministic tests and demos.
- Add TTS interfaces and a `PiperTTS` adapter with an offline fallback tone in `src/voice_interface/tts/`, an energy-based `EnergyVAD` in `src/voice_interface/audio/vad.py`, a full-duplex conversation orchestrator in `src/voice_interface/conversation/loop.py`, and a simple plugin registry in `src/voice_interface/plugins/registry.py`.
- Add a CLI entry point `src/voice_interface/cli.py`, design notes `docs/voice-interface.md`, update `README.md` for the new project, and update `pyproject.toml` to rename the project to `voice-interface`, add optional dependency extras, and register the `voice-interface` console script while preserving `limitless-index`.
- Add unit tests in `tests/test_voice_interface.py` covering the conversation loop, VAD behavior, plugin dispatch, and the CLI demo.

### Testing
- Ran `pytest -q` and all tests passed (`8 passed`).
- Ran a CLI smoke demo with `PYTHONPATH=src python -m voice_interface.cli demo --say 'Hello room.'` which produced the expected `user:` and `assistant:` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aa0d023a0832f8d6cf5e575e4a95e)